### PR TITLE
Fix Rust cache key to be platform-dependent

### DIFF
--- a/.github/workflows/rust-exe.yml
+++ b/.github/workflows/rust-exe.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: ${{ matrix.target.triple }}
-          rust_cache_key: v0
+          rust_cache_key: v0-${{ matrix.target.os }}-${{ matrix.target.triple }}
           just_bootstrap: ${{ inputs.just_bootstrap }}
 
       - name: Build


### PR DESCRIPTION
In https://github.com/indygreg/apple-platform-rs/actions/runs/20708695202/job/59444213251, we see a build error on Ubuntu 22.04 (glibc 2.35) because some part of the cache was built with Ubuntu 24.04 (glibc 2.39).

This appears to happen because the `Swatinem-rust-cache` action caches the Rust binaries for the Linux x86 platform, but it does not distiniguish between Ubuntu 22.04 and 24.04.

To fix this make the cache key dependent on the OS and target.